### PR TITLE
Fix install_requires

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,8 @@
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix install_requires to specify correct dependencies.
+  [gforcada]
 
 
 1.0a1 (2014-04-17)

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,14 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        'plone.app.dexterity',
-        'plone.app.z3cform'
+        'plone.app.z3cform',
+        'plone.schemaeditor',
+        'plone.supermodel',
+        'z3c.form',
+        'zope.component'
+        'zope.i18nmessageid',
+        'zope.interface',
+        'zope.schema',
     ],
     extras_require={
         'test': ['plone.app.testing'],


### PR DESCRIPTION
There's no import/zcml dependency on plone.app.dexterity.

All other imports come from z3c.dependencychecker analysis.