### PR TITLE
Add field attribute 'widget' to field Dict from zope.schema

### DIFF
--- a/news/14.feature
+++ b/news/14.feature
@@ -1,0 +1,1 @@
+Add field attribute 'widget' to field Dict from zope.schema. [ksuess]

--- a/plone/schema/__init__.py
+++ b/plone/schema/__init__.py
@@ -11,6 +11,9 @@ from .path import IPath
 from .jsonfield import JSONField
 from .jsonfield import IJSONField
 
+from .dict import Dict
+from zope.schema.interfaces import IDict
+
 # zope.schema convenience imports
 from zope.schema._field import ASCII
 from zope.schema._field import ASCIILine
@@ -22,7 +25,6 @@ from zope.schema._field import Container
 from zope.schema._field import Date
 from zope.schema._field import Datetime
 from zope.schema._field import Decimal
-from zope.schema._field import Dict
 from zope.schema._field import DottedName
 from zope.schema._field import Field
 from zope.schema._field import Float

--- a/plone/schema/dict.py
+++ b/plone/schema/dict.py
@@ -1,0 +1,15 @@
+from zope.interface import implementer
+from zope.schema import Dict as ZopeDictField
+from zope.schema.interfaces import IDict
+from zope.schema.interfaces import WrongType
+
+
+@implementer(IDict)
+class Dict(ZopeDictField):
+    def __init__(self, widget=None, **kw):
+        if widget and not isinstance(widget, str):
+            raise WrongType
+
+        self.widget = widget
+
+        super(Dict, self).__init__(**kw)


### PR DESCRIPTION
As the Dict field is a mighty field that can be used for many diverse dictionaries and diverse use cases, we need the widget info to let Volto know which Widget to apply.